### PR TITLE
Add administrative files

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,5 @@
+The below people have contributed to the BDK project:
+
+- Vineet Marri <vineet.marri03@gmail.com>
+- Zhuowei Wen <wzhuo17@gmail.com>
+- Shaddi Hasan <shaddi@vt.edu>

--- a/DCO.md
+++ b/DCO.md
@@ -1,0 +1,37 @@
+# DCO
+
+You must sign-off all commits on the originating branch for a PR, which certifies that you wrote it or otherwise have the right to pass it on as an open-source contribution.
+The rules are pretty simple: if you can certify the below (from [developercertificate.org](https://developercertificate.org/)):
+
+> Developer's Certificate of Origin 1.1
+>
+> By making a contribution to this project, I certify that:
+>
+> (a) The contribution was created in whole or in part by me and I
+> have the right to submit it under the open source license
+> indicated in the file; or
+>
+> (b) The contribution is based upon previous work that, to the best
+> of my knowledge, is covered under an appropriate open source
+> license and I have the right under that license to submit that
+> work with modifications, whether created in whole or in part
+> by me, under the same open source license (unless I am
+> permitted to submit under a different license), as indicated
+> in the file; or
+>
+> (c) The contribution was provided directly to me by some other
+> person who certified (a), (b) or (c) and I have not modified
+> it.
+>
+> (d) I understand and agree that this project and the contribution
+> are public and that a record of the contribution (including all
+> personal information I submit with it, including my sign-off) is
+> maintained indefinitely and may be redistributed consistent with
+> this project or the open source license(s) involved.
+
+Then you just add a line to every git commit message:
+
+> Signed-off-by: Your Name <your.name@example.com>
+
+You need to use your real name to contribute (sorry, no pseudonyms or anonymous contributions).
+If you set your user.name and user.email git configs, you can sign your commit automatically with [git commit -s](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s). If you've forgotten to sign off on a commit, you can do so retroactively with `git commit --amend -s`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,30 @@
+BSD 3-Clause License
+
+For Broadband Data Kit (BDK) software
+
+Copyright (c) 2023, The Broadband Data Kit Authors
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Adds a LICENSE document, a contributors document, and a DCO for third party contributions. Note the DCO will now require folks to use the `-s/--signoff` option on commits.