### PR TITLE
Consolidate tile rebuild pipeline

### DIFF
--- a/back-end/alembic/versions/b7c4a9e2d5f1_add_markers_to_editfile.py
+++ b/back-end/alembic/versions/b7c4a9e2d5f1_add_markers_to_editfile.py
@@ -1,0 +1,27 @@
+"""add markers to editfile
+
+Persist an edit's exact per-point picks alongside its polygon so recomputes
+can re-apply the edit exactly instead of geometrically (polygon ∩ linked
+coverage files). NULL means a pre-existing editfile; those keep the geometric
+re-apply behavior.
+
+Revision ID: b7c4a9e2d5f1
+Revises: c4d2e8f1a6b3
+Create Date: 2026-06-09
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "b7c4a9e2d5f1"
+down_revision = "c4d2e8f1a6b3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("editfile", sa.Column("markers", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("editfile", "markers")

--- a/back-end/controllers/celery_controller/celery_tasks.py
+++ b/back-end/controllers/celery_controller/celery_tasks.py
@@ -153,23 +153,15 @@ def process_data(self, folderid, operation):
 
             file.computed = True
 
-        geojson_array = []
-        # This is a temporary solution, we should try optimize to use tile-join
-        all_kmls = file_ops.get_files_with_postfix(folderid, ".kml", session)
-        for kml_f in all_kmls:
-            geojson_array.append(vt_ops.read_kml(kml_f.id, session))
-
-        all_geojsons = file_ops.get_files_with_postfix(folderid, ".geojson", session)
-        for geojson_f in all_geojsons:
-            geojson_array.append(vt_ops.read_geojson(geojson_f.id, session))
-
-        mbtiles_ops.delete_mbtiles(folderid, session)
         session.commit()
         logger.info("finished coverage points computation, now creating vector tiles")
-
-        vt_ops.create_tiles(geojson_array, folderid, session)
-
         session.close()
+
+        # Tile building goes through the same per-folder single-flight path as
+        # edit retiles, so upload/delete/regenerate rebuilds coalesce with (and
+        # never race) edit rebuilds. Returns once the tiles cover this change.
+        _mark_tiles_dirty(folderid)
+        _coalesced_tile_rebuild(folderid, self.request.id)
 
     except Exception as e:
         session.close()
@@ -348,13 +340,13 @@ def _rebuild_folder_tiles(folderid):
         session.close()
 
 
-@celery.task(bind=True, autoretry_for=(Exception,), retry_backoff=True)
-def regenerate_tiles(self, folderid):
-    """Rebuild the folder's tiles, single-flight + coalescing. Every edit's
-    apply phase sets the dirty flag; the rebuild that runs after it clears it.
-    A queued regenerate that finds the folder clean no-ops (an earlier rebuild
-    already covered its edit), so N rapid edits cost ~1 rebuild, while 'task
-    SUCCESS' still always means 'the tiles include this chain's edit'."""
+def _coalesced_tile_rebuild(folderid, owner_id):
+    """Rebuild a folder's tiles, single-flight + coalescing. Callers mark the
+    folder dirty after changing its data; the rebuild that runs after that
+    clears the flag. A caller that finds the folder clean no-ops (an earlier
+    rebuild already covered its change), so N rapid changes cost ~1 rebuild.
+    Returns only once the tiles cover the caller's change. Without redis, the
+    debounce degrades to always rebuilding (correct, less efficient)."""
     r = _tiles_redis()
     if r is None:
         _rebuild_folder_tiles(folderid)
@@ -363,7 +355,7 @@ def regenerate_tiles(self, folderid):
     lock_key = TILES_LOCK_KEY.format(folderid=folderid)
     dirty_key = TILES_DIRTY_KEY.format(folderid=folderid)
     waited = 0
-    while not r.set(lock_key, str(self.request.id), nx=True, ex=TILES_LOCK_TTL):
+    while not r.set(lock_key, str(owner_id), nx=True, ex=TILES_LOCK_TTL):
         if waited >= TILES_LOCK_WAIT:
             raise Exception(f"timed out waiting for the tile-rebuild lock on folder {folderid}")
         time.sleep(5)
@@ -376,6 +368,14 @@ def regenerate_tiles(self, folderid):
         return "tiles rebuilt"
     finally:
         r.delete(lock_key)
+
+
+@celery.task(bind=True, autoretry_for=(Exception,), retry_backoff=True)
+def regenerate_tiles(self, folderid):
+    """The slow half of an edit chain: rebuild the folder's tiles via the
+    shared coalescing path. 'Task SUCCESS' always means 'the tiles include
+    this chain's edit'."""
+    return _coalesced_tile_rebuild(folderid, self.request.id)
 
 
 @celery.task(bind=True, autoretry_for=(Exception,), retry_backoff=True)

--- a/back-end/controllers/celery_controller/celery_tasks.py
+++ b/back-end/controllers/celery_controller/celery_tasks.py
@@ -240,6 +240,9 @@ def apply_edit_changes(self, markers, folderid, polygonfeatures):
                     content=feature_binary,
                     folderid=folderid,
                     session=session,
+                    # the exact per-point picks, so recomputes re-apply this
+                    # edit exactly instead of geometrically
+                    markers=markers[index] or None,
                 )
                 session.commit()
 

--- a/back-end/controllers/database_controller/editfile_ops.py
+++ b/back-end/controllers/database_controller/editfile_ops.py
@@ -47,7 +47,7 @@ def get_editfile_with_id(fileid, session=None):
             session.close()
 
 
-def create_editfile(filename, content, folderid, session=None):
+def create_editfile(filename, content, folderid, session=None, markers=None):
     owns_session = False
     if session is None:
         session = Session()
@@ -55,7 +55,11 @@ def create_editfile(filename, content, folderid, session=None):
 
     try:
         new_file = editfile(
-            name=filename, data=content, folder_id=folderid, timestamp=datetime.now()
+            name=filename,
+            data=content,
+            markers=markers,
+            folder_id=folderid,
+            timestamp=datetime.now(),
         )
         session.add(new_file)
         if owns_session:

--- a/back-end/controllers/database_controller/kml_ops.py
+++ b/back-end/controllers/database_controller/kml_ops.py
@@ -313,10 +313,23 @@ def rename_conflicting_columns(gdf):
 
 
 def filter_points_within_editfile_polygons(points_gdf, coverage_file, session):
+    """Drop the points this coverage file's linked editfiles exclude.
+
+    Editfiles that carry per-point markers are applied exactly: only the
+    marked location_ids whose pick names this coverage file are dropped.
+    Editfiles without markers (created before markers were persisted) fall
+    back to the geometric rule: every point inside the polygon is dropped.
+    """
     all_polygons = []
+    excluded_ids = set()
 
     editfiles = get_editfiles_for_file(coverage_file.id, session)
     for editfile in editfiles:
+        if editfile.markers:
+            for marker in editfile.markers:
+                if coverage_file.name in (marker.get("editedFile") or []):
+                    excluded_ids.add(int(marker["id"]))
+            continue
         try:
             geojson_feature = json.loads(editfile.data.decode("utf-8"))
             if geojson_feature["geometry"]["type"] == "Polygon":
@@ -325,6 +338,9 @@ def filter_points_within_editfile_polygons(points_gdf, coverage_file, session):
         except json.JSONDecodeError:
             logger.error("Failed to decode JSON data")
             continue
+
+    if excluded_ids:
+        points_gdf = points_gdf[~points_gdf["location_id"].astype(int).isin(excluded_ids)]
 
     if all_polygons:
         polygons_gdf = geopandas.GeoDataFrame(geometry=all_polygons, crs="EPSG:4326")

--- a/back-end/database/models.py
+++ b/back-end/database/models.py
@@ -281,6 +281,11 @@ class editfile(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String, nullable=False)
     data = Column(LargeBinary)
+    # The exact per-point picks this edit made: [{"id": <location_id>,
+    # "editedFile": [<coverage filenames>]}, ...]. NULL for editfiles created
+    # before markers were persisted — recomputes then fall back to applying
+    # the polygon geometrically (see kml_ops.filter_points_within_editfile_polygons).
+    markers = Column(JSON)
     folder_id = Column(Integer, ForeignKey("folder.id", ondelete="CASCADE"))
     timestamp = Column(DateTime)
     folder = relationship("folder", back_populates="editfiles")
@@ -290,6 +295,7 @@ class editfile(Base):
         new_edit_file = editfile(
             name=self.name,
             data=self.data,
+            markers=self.markers,
             folder_id=new_folder_id,
             timestamp=datetime.now(),
         )

--- a/back-end/tests/test_edit_markers.py
+++ b/back-end/tests/test_edit_markers.py
@@ -1,0 +1,114 @@
+"""Per-point edit markers persisted with editfiles.
+
+An exclusion edit knows exactly which locations were excluded from which
+coverage files (the markers). Historically only the drawn polygon was
+persisted, so any recompute (e.g. after deleting a different editfile)
+re-applied edits *geometrically* — polygon ∩ linked coverage — which is
+broader than the original per-point picks (a multi-coverage partial pick
+became a blanket exclusion). Markers are now stored on the editfile and the
+recompute honors them exactly; editfiles without markers (all pre-existing
+data) keep the geometric behavior.
+"""
+
+import geopandas as gpd
+from shapely.geometry import Point
+
+from tests import conftest_helpers as H
+
+POLYGON = {
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [[-80.01, 37.27], [-80.0, 37.27], [-80.0, 37.28], [-80.01, 37.28], [-80.01, 37.27]]
+        ],
+    },
+}
+
+
+# three fabric points, all INSIDE the polygon above
+def _points_gdf():
+    return gpd.GeoDataFrame(
+        {"location_id": [1, 2, 3]},
+        geometry=[Point(-80.005, 37.275), Point(-80.004, 37.274), Point(-80.003, 37.273)],
+        crs="EPSG:4326",
+    )
+
+
+def _seed(s, markers):
+    import json
+
+    from controllers.database_controller import editfile_ops, file_editfile_link_ops
+
+    org = H.make_org(s)
+    folder = H.make_folder(s, org.id)
+    cov = H.seed_coverage(s, folder.id, b"stub", "cov.kml", "wired", 50)
+    ef = editfile_ops.create_editfile(
+        filename="edit_at_test",
+        content=json.dumps(POLYGON).encode("utf-8"),
+        folderid=folder.id,
+        session=s,
+        markers=markers,
+    )
+    s.commit()
+    file_editfile_link_ops.link_file_and_editfile(cov.id, ef.id, s)
+    s.commit()
+    return folder, cov, ef
+
+
+def test_filter_honors_markers_exactly(db_session):
+    """With markers, only the marked locations are excluded — and only for the
+    coverage files the marker names. Unmarked points inside the polygon stay."""
+    from controllers.database_controller import kml_ops
+
+    s = db_session
+    _, cov, _ = _seed(
+        s,
+        markers=[
+            {"id": 1, "editedFile": ["cov.kml"]},
+            {"id": 2, "editedFile": ["other.geojson"]},  # excluded from a DIFFERENT file
+        ],
+    )
+    out = kml_ops.filter_points_within_editfile_polygons(_points_gdf(), cov, s)
+    assert set(out["location_id"]) == {2, 3}
+
+
+def test_filter_without_markers_stays_geometric(db_session):
+    """Editfiles with no markers (all pre-existing data) keep the legacy
+    behavior: every point inside the polygon is excluded."""
+    from controllers.database_controller import kml_ops
+
+    s = db_session
+    _, cov, _ = _seed(s, markers=None)
+    out = kml_ops.filter_points_within_editfile_polygons(_points_gdf(), cov, s)
+    assert set(out["location_id"]) == set()
+
+
+def test_apply_edit_changes_stores_markers(db_session, monkeypatch):
+    from controllers.celery_controller import celery_tasks as ct
+    from database.models import editfile, kml_data
+
+    s = db_session
+    org = H.make_org(s)
+    folder = H.make_folder(s, org.id)
+    cov = H.seed_coverage(s, folder.id, b"stub", "cov.kml", "wired", 50)
+    s.add(kml_data(location_id=1, served=True, file_id=cov.id, longitude=-80.005, latitude=37.275))
+    s.commit()
+
+    markers = [[{"id": 1, "editedFile": ["cov.kml"]}]]
+    ct.apply_edit_changes.apply_async(args=[markers, folder.id, [POLYGON]]).get()
+
+    s.expire_all()
+    ef = s.query(editfile).filter(editfile.folder_id == folder.id).one()
+    assert ef.markers == markers[0]
+
+
+def test_editfile_copy_preserves_markers(db_session):
+    s = db_session
+    _, _, ef = _seed(s, markers=[{"id": 1, "editedFile": ["cov.kml"]}])
+    org2 = H.make_org(s, name="Org2", provider_id=999999)
+    folder2 = H.make_folder(s, org2.id)
+    clone = ef.copy(session=s, new_folder_id=folder2.id)
+    s.commit()
+    assert clone.markers == ef.markers

--- a/back-end/tests/test_tiles_split.py
+++ b/back-end/tests/test_tiles_split.py
@@ -50,11 +50,13 @@ class _StubRedis:
 
     def __init__(self):
         self.store = {}
+        self.sets = []  # every key ever set, for asserting the lock was taken
 
     def set(self, key, value, nx=False, ex=None):
         if nx and key in self.store:
             return False
         self.store[key] = value
+        self.sets.append(key)
         return True
 
     def get(self, key):
@@ -133,6 +135,26 @@ def test_regenerate_tiles_coalesces_when_fresh(db_session, tasks, monkeypatch):
     assert calls["create_tiles"] == [folder.id]
     assert "rebuilt" in res
     assert stub.get(f"bdk:tiles-dirty:{folder.id}") is None
+    assert stub.get(f"bdk:tiles-lock:{folder.id}") is None  # lock released
+
+
+def test_process_data_uses_coalesced_rebuild(db_session, tasks, monkeypatch):
+    """process_data's tile step goes through the same per-folder lock +
+    dirty-flag path as edit retiles, so upload/delete/regenerate rebuilds
+    coalesce with edit rebuilds instead of racing them."""
+    ct, calls = tasks
+    s = db_session
+    _, _, folder, _ = _seed_edit_fixture(s)
+    stub = _StubRedis()
+    monkeypatch.setattr(ct, "_tiles_redis", lambda: stub)
+    # stub the heavy coverage compute; we're testing the tile-step plumbing
+    monkeypatch.setattr(ct.kml_ops, "add_network_data", lambda *a, **k: None)
+
+    ct.process_data.apply_async(args=[folder.id, 1]).get()
+
+    assert calls["create_tiles"] == [folder.id]
+    assert any(k == f"bdk:tiles-lock:{folder.id}" for k in stub.sets)  # lock taken
+    assert stub.get(f"bdk:tiles-dirty:{folder.id}") is None  # marked + consumed
     assert stub.get(f"bdk:tiles-lock:{folder.id}") is None  # lock released
 
 


### PR DESCRIPTION
Two related changes to the tile update/edit/rebuild pipeline. First, we now preserve the exact BSLs edited at edit time rather than just capturing the edit polygon; this keeps later recomputes (e.g. after deleting an edit) from re-applying an edit more broadly than the user's original selection. Existing edits without stored selections keep the old polygon-based behavior. Second, the map update path (e.g., uploading new coverage files) now uses the same rebuild path as the edit flow, which serializes simultaneous rebuilds of a filing and reduces unnecessary rebuilds.