### PR TITLE
deploy: harden first bring-up and backups

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -45,8 +45,13 @@ migrations against the empty database.
 
 ## Backups
 
-A nightly cron on the data host (see DEPLOYMENT notes; not part of compose):
+`backup.sh`, run nightly from cron on the data host (as the deploy user):
 
-    pg_dump -Fc -h localhost -U bdk bdk > /backups/bdk-$(date +%F).dump
+    0 3 * * * /opt/bdk/deploy/backup.sh >> /backups/backup.log 2>&1
 
-Keep at least 14 days and copy them off-host.
+It dumps through the db container (socket auth — no password on the host),
+writes atomically, and prunes to a tiered retention under `/backups`:
+14 daily, 8 weekly (Sundays), 12 monthly (the 1st). Worst-case disk is the
+sum of those counts times the dump size. Verify the first cron run produced
+a real file. The dumps hold provider data — trusted storage only; copy the
+monthlies off-host.

--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Nightly BDK database backup with tiered retention — run from cron on the
+# DATA host. Dumps through the running db container (unix-socket auth, so no
+# password lives on the host), writes atomically (.part then rename), then
+# prunes:
+#
+#   daily/    every run             kept DAILY_KEEP   days   (default 14)
+#   weekly/   Sunday's dump copied  kept WEEKLY_KEEP  weeks  (default 8)
+#   monthly/  the 1st's dump copied kept MONTHLY_KEEP months (default 12)
+#
+# Worst-case disk = (DAILY_KEEP + WEEKLY_KEEP + MONTHLY_KEEP) x dump size.
+# Dumps hold provider data — keep them on trusted storage only; copy the
+# monthlies off-host.
+#
+# Cron (as the deploy user):
+#   0 3 * * * /opt/bdk/deploy/backup.sh >> /backups/backup.log 2>&1
+#
+# COMPOSE_DIR overrides where data/.env + the compose project live, for
+# running a copy of this script from outside the pinned checkout.
+set -eu
+
+BACKUP_ROOT=${BACKUP_ROOT:-/backups}
+DAILY_KEEP=${DAILY_KEEP:-14}
+WEEKLY_KEEP=${WEEKLY_KEEP:-8}
+MONTHLY_KEEP=${MONTHLY_KEEP:-12}
+COMPOSE_DIR=${COMPOSE_DIR:-"$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/data"}
+
+. "$COMPOSE_DIR/.env"
+cd "$COMPOSE_DIR"
+DBC=$(docker compose --env-file .env ps -q db)
+[ -n "$DBC" ] || { echo "db container not running — no backup taken"; exit 1; }
+
+TODAY=$(date +%F)
+mkdir -p "$BACKUP_ROOT/daily" "$BACKUP_ROOT/weekly" "$BACKUP_ROOT/monthly"
+
+OUT="$BACKUP_ROOT/daily/bdk-$TODAY.dump"
+docker exec "$DBC" pg_dump -Fc -U "$POSTGRES_USER" "$POSTGRES_DB" > "$OUT.part"
+[ "$(head -c 5 "$OUT.part")" = "PGDMP" ] || {
+  echo "output is not a pg_dump archive — keeping $OUT.part for inspection"
+  exit 1
+}
+mv "$OUT.part" "$OUT"
+echo "$TODAY: $(du -h "$OUT" | cut -f1) -> $OUT"
+
+[ "$(date +%u)" = "7" ] && cp "$OUT" "$BACKUP_ROOT/weekly/"
+[ "$(date +%d)" = "01" ] && cp "$OUT" "$BACKUP_ROOT/monthly/"
+
+find "$BACKUP_ROOT/daily" -name 'bdk-*.dump' -mtime +"$DAILY_KEEP" -delete
+find "$BACKUP_ROOT/weekly" -name 'bdk-*.dump' -mtime +$((WEEKLY_KEEP * 7)) -delete
+find "$BACKUP_ROOT/monthly" -name 'bdk-*.dump' -mtime +$((MONTHLY_KEEP * 31)) -delete
+find "$BACKUP_ROOT" -name '*.dump.part' -mtime +1 -delete

--- a/deploy/restore-and-migrate.sh
+++ b/deploy/restore-and-migrate.sh
@@ -20,6 +20,11 @@ cd "$DIR/data"
 DBC=$(docker compose --env-file .env ps -q db)
 [ -n "$DBC" ] || { echo "db container not running (docker compose up -d db first)"; exit 1; }
 
+# The postgis image auto-creates the (unused) extension on first boot; drop
+# it so its spatial_ref_sys table doesn't fail the emptiness check below.
+docker exec "$DBC" psql -U "$POSTGRES_USER" -d "$DB" -c \
+  "DROP EXTENSION IF EXISTS postgis CASCADE" >/dev/null
+
 TABLES=$(docker exec "$DBC" psql -U "$POSTGRES_USER" -d "$DB" -tAc \
   "SELECT count(*) FROM pg_tables WHERE schemaname='public'")
 [ "$TABLES" = "0" ] || { echo "database is not empty ($TABLES tables) — refusing to restore"; exit 1; }


### PR DESCRIPTION
- restore-and-migrate.sh: drop the postgis extension the image auto-creates on a fresh PGDATA before the emptiness guard (its spatial_ref_sys table made the guard refuse a genuinely fresh database). The extension software stays in the image; enabling PostGIS later is still a one-line migration.
- backup.sh (new): nightly dump through the db container with tiered retention (14 daily / 8 weekly / 12 monthly), atomic write with an archive-magic sanity check, socket auth so no password lives on the host. Replaces the raw pg_dump cron line in the README.